### PR TITLE
Add epAng variable, fix electron target hit position

### DIFF
--- a/pyEcalVeto/mods/physTools.py
+++ b/pyEcalVeto/mods/physTools.py
@@ -416,22 +416,54 @@ def hcal_strip(hit):
 # Get e/g SP hit info
 ###########################
 
-# Get electron target scoring plane hit
-def electronTargetSPHit(targetSPHits):
+# Get electron hit with max p at any scoring plane
+def maxPElectronSPHit(SPHits, sp_z):
+    
+    p_max = 0
+    Hit_maxP = None
+    for hit in SPHits:
 
-    targetSPHit = None
-    pmax = 0
-    for hit in targetSPHits:
-
-        if abs(hit.getPosition()[2] - sp_trigger_pad_down_l2_z) > 0.5*sp_thickness or\
+        if abs(hit.getPosition()[2] - sp_z) > 0.5*sp_thickness or\
                 hit.getMomentum()[2] <= 0 or\
                 hit.getTrackID() != 1 or\
                 hit.getPdgID() != 11:
             continue
 
-        if mag(hit.getMomentum()) > pmax:
-            targetSPHit = hit
-            pmax = mag(targetSPHit.getMomentum())
+        if mag(hit.getMomentum()) > p_max:
+            Hit_maxP = hit
+            p_max = mag(hit.getMomentum())
+    
+    return p_max, Hit_maxP
+
+# Get electron target scoring plane hit
+def electronTargetSPHit(targetSPHits):
+    
+    E_threshold = 3000    # 3 GeV threshold, may need to modify
+    targetSPHit = None
+    pmax = 0
+    
+    # 1. Interact @ Target
+    pmax, targetSPHit = maxPElectronSPHit(targetSPHits, sp_target_down_z)
+    if pmax > E_threshold:
+        # 2. Interact @ Trigger scin l1
+        pmax, targetSPHit = maxPElectronSPHit(targetSPHits, sp_trigger_pad_down_l1_z)
+        if pmax > E_threshold:
+            # 3. Interact @ Trigger scin l2
+            pmax, targetSPHit = maxPElectronSPHit(targetSPHits, sp_trigger_pad_down_l2_z)
+
+
+    # Assume e- interacting @ Target   
+    # for hit in targetSPHits:
+
+    #     if abs(hit.getPosition()[2] - sp_target_down_z) > 0.5*sp_thickness or\
+    #             hit.getMomentum()[2] <= 0 or\
+    #             hit.getTrackID() != 1 or\
+    #             hit.getPdgID() != 11:
+    #         continue
+
+    #     if mag(hit.getMomentum()) > pmax:
+    #         targetSPHit = hit
+    #         pmax = mag(targetSPHit.getMomentum())
 
     return targetSPHit
 

--- a/pyEcalVeto/treeMaker.py
+++ b/pyEcalVeto/treeMaker.py
@@ -32,7 +32,8 @@ branches_info = {
         'photonTerritoryHits':       {'rtype': int,   'default': 0 },
         'TerritoryRatio':            {'rtype': float, 'default': 1.},
         'epSep':                     {'rtype': float, 'default': 0.},
-        'epDot':                     {'rtype': float, 'default': 0.}
+        'epDot':                     {'rtype': float, 'default': 0.},
+        'epAng':                     {'rtype': float, 'default': 0.}
         }
 
 for i in range(1, physTools.nSegments + 1):
@@ -223,6 +224,8 @@ def event_process(self):
         g_norm  = physTools.unit( g_traj_ends[1] - g_traj_ends[0] )
         feats['epSep'] = physTools.dist( e_traj_ends[0], g_traj_ends[0] )
         feats['epDot'] = physTools.dot(e_norm,g_norm)
+        # Add epAng
+        feats['epAng'] = math.acos(physTools.dot(e_norm,g_norm)) * 180.0 / math.pi
 
     else:
 
@@ -233,7 +236,8 @@ def event_process(self):
         g_traj_ends   = [np.array([1000,1000,0   ]), np.array([1000,1000,1000]) ]
 
         feats['epSep'] = 10.0 + 1.0 # Don't cut on these in this case
-        feats['epDot'] = 3.0 + 1.0
+        feats['epDot'] = 3.0 + 1.0 # ? This default value should be assigned to an angle
+        feats['epAng'] = 3.0 + 1.0
 
     # Territory setup (consider missing case)
     gToe    = physTools.unit( e_traj_ends[0] - g_traj_ends[0] )


### PR DESCRIPTION
The default value (non-fiducial case) for epAng is set to 3.0 + 1.0 according to [MIP tracking](https://github.com/LDMX-Software/Ecal/blob/a4bca7d0743adcd5ac079bb7bd0b976f450afb2f/src/Ecal/EcalVetoProcessor.cxx#L573) settings.