### PR TITLE
Update EcalVeto-3.0/pickle_to_onnx.py: non-default feature names, any n_features, command line arguments 

### DIFF
--- a/EcalVeto-3.0/pickle_to_onnx.py
+++ b/EcalVeto-3.0/pickle_to_onnx.py
@@ -17,8 +17,6 @@ with open(args.infile, "rb") as f:
     outfilename = os.path.basename(args.infile).replace('.pkl', '.onnx')
     feature_names = clf.feature_names
 
-print(f'Feature names before conversion:\n{feature_names}')
-
 # the xgboost converter in onnxmltools can only parse default feature names assigned
 # by xgboost, i.e. f0, f1, f2, etc. The below block of code checks whether the feature
 # names assigned in the process of training the model are default or otherwise out of
@@ -36,12 +34,9 @@ if not all(feat == 'f%d' % i for i, feat in enumerate(feature_names)):
 else:
     print('Feature names are default and in the correct order.')
 
-print(f'Feature names after conversion:\n{clf.feature_names}')
-
 outfilepath = os.path.join(args.outdir, outfilename)
 
 n_features = clf.num_features()
-print(f'num_features = {n_features}')
 onnx_model = onnxmltools.convert_xgboost(clf, initial_types=[('input', FloatTensorType([None, n_features]))])
 
 with open(outfilepath, "wb") as f:

--- a/EcalVeto-3.0/pickle_to_onnx.py
+++ b/EcalVeto-3.0/pickle_to_onnx.py
@@ -1,13 +1,50 @@
 import pickle
 import onnxmltools
 from onnxmltools.convert.common.data_types import FloatTensorType
+import argparse
+from ast import arg
+import os
 
-with open("/home/xinyi_xu/ldmx-sw/ldmx-sw/LDMX-scripts/pyEcalVeto/bdt_test_0/bdt_test_0_weights.pkl", "rb") as f:
+print('All packages imported successfully')
+
+parser = argparse.ArgumentParser(description='Converts a pkl filetype to onnx filetype.')
+parser.add_argument('-i','--infile', type=str, action='store', dest='infile', help='Absolute path to input file')
+parser.add_argument('-o','--outdir', type=str, action='store', dest='outdir', help='Directory of output file, absolute path')
+args = parser.parse_args()
+
+with open(args.infile, "rb") as f:
     clf = pickle.load(f)
+    outfilename = os.path.basename(args.infile).replace('.pkl', '.onnx')
+    feature_names = clf.feature_names
 
-n_features = 47 
+print(f'Feature names before conversion:\n{feature_names}')
+
+# the xgboost converter in onnxmltools can only parse default feature names assigned
+# by xgboost, i.e. f0, f1, f2, etc. The below block of code checks whether the feature
+# names assigned in the process of training the model are default or otherwise out of
+# order and thus unparseable by the onnx converter. If they are non-default, it
+# temporarily assigns default feature names in the same order as the read-in feature
+# names (changing the feature names in memory but NOT in the pickle file or the model
+# itself) so that the onnx converter can properly convert the xgboost.Booster() object
+# to an onnx filetype.
+
+if not all(feat == 'f%d' % i for i, feat in enumerate(feature_names)):
+    print('Feature names are either non-default or out of order.\nAssigning default names for onnx converter...')
+    clf.feature_names = ['f%d' % i for i in range(len(feature_names))]
+    print('Feature names are assigned. NOTE: This does not change the source pickle file.')
+    # print(clf.feature_names)
+else:
+    print('Feature names are default and in the correct order.')
+
+print(f'Feature names after conversion:\n{clf.feature_names}')
+
+outfilepath = os.path.join(args.outdir, outfilename)
+
+n_features = clf.num_features()
+print(f'num_features = {n_features}')
 onnx_model = onnxmltools.convert_xgboost(clf, initial_types=[('input', FloatTensorType([None, n_features]))])
-with open("bdt_test_0_weights_f.onnx", "wb") as f:
+
+with open(outfilepath, "wb") as f:
     f.write(onnx_model.SerializeToString())
 
-print("ONNX model saved as bdt_test_0_weights_f.onnx")
+print(f"ONNX model saved as {outfilename} in {args.outdir}")


### PR DESCRIPTION
The previous update to bdtMaker.py (https://github.com/IncandelaLab/LDMX-scripts/pull/72) introduced non-default feature names; the onnxmltools package can only handle default feature names (see [HERE](https://github.com/onnx/onnxmltools/blob/095381993a18d2e3dedfe422c3a5816a793030d3/onnxmltools/convert/xgboost/operator_converters/XGBoost.py#L110)). This introduces handling of non-default feature names for conversion to onnx filetypes and generalizes to an arbitrary number of features in the BDT rather than only the preset 47.

Also, introduced argparse command line arguments for general applicability.